### PR TITLE
Add stdint to encoding.h so it builds on Linux

### DIFF
--- a/src/encoding.h
+++ b/src/encoding.h
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdint.h>
 #include "memory.h"
 
 struct lineInfo


### PR DESCRIPTION
Ran `make build` on Ubuntu (to work around an apparent Mac compatibility issue with `gdb` while debugging a segfault) and got:
```sh
$ make build
mkdir -p bin
gcc -Ofast src/memory.c src/urlopen.c src/encoding.c src/csv.c src/writer.c src/fec.c -l curl -l pcre src/main.c -o bin/fastfec
src/encoding.c:11:14: error: unknown type name ‘uint8_t’
   11 | static const uint8_t utf8d[] = {
      |              ^~~~~~~
src/encoding.c: In function ‘collectLineInfo’:
src/encoding.c:35:3: error: unknown type name ‘uint32_t’; did you mean ‘u_int32_t’?
   35 |   uint32_t state = UTF8_ACCEPT;
      |   ^~~~~~~~
      |   u_int32_t
src/encoding.c:36:3: error: unknown type name ‘uint32_t’; did you mean ‘u_int32_t’?
   36 |   uint32_t type;
      |   ^~~~~~~~
      |   u_int32_t
src/encoding.c:59:19: error: ‘uint8_t’ undeclared (first use in this function); did you mean ‘u_int8_t’?
   59 |     type = utf8d[(uint8_t)c];
      |                   ^~~~~~~
      |                   u_int8_t
src/encoding.c:59:19: note: each undeclared identifier is reported only once for each function it appears in
src/encoding.c:59:27: error: expected ‘]’ before ‘c’
   59 |     type = utf8d[(uint8_t)c];
      |                           ^
      |                           ]
src/encoding.c: In function ‘iso_8859_1_to_utf_8’:
src/encoding.c:75:3: error: unknown type name ‘uint8_t’; did you mean ‘u_int8_t’?
   75 |   uint8_t *line = (uint8_t *)in->str;
      |   ^~~~~~~
      |   u_int8_t
src/encoding.c:75:20: error: ‘uint8_t’ undeclared (first use in this function); did you mean ‘u_int8_t’?
   75 |   uint8_t *line = (uint8_t *)in->str;
      |                    ^~~~~~~
      |                    u_int8_t
src/encoding.c:75:29: error: expected expression before ‘)’ token
   75 |   uint8_t *line = (uint8_t *)in->str;
      |                             ^
src/encoding.c:76:12: error: ‘out’ undeclared (first use in this function)
   76 |   uint8_t *out = (uint8_t *)output->str;
      |            ^~~
src/encoding.c:76:28: error: expected expression before ‘)’ token
   76 |   uint8_t *out = (uint8_t *)output->str;
      |                            ^
make: *** [Makefile:10: build] Error 1
```

This fixes that by adding `stdint.h` as a header.
