### PR TITLE
fix: normalize the filename to prevent errors with slashes in form types

### DIFF
--- a/src/writer.c
+++ b/src/writer.c
@@ -50,6 +50,18 @@ int mkdir_p(const char *path)
   return 0;
 }
 
+// Normalize a file name by converting slashes to dashes
+// Adapted from https://stackoverflow.com/a/32496721
+void normalize_filename(char *filename)
+{
+  char *current_pos = strchr(filename, '/');
+  while (current_pos)
+  {
+    *current_pos = '-';
+    current_pos = strchr(current_pos, '/');
+  }
+}
+
 WRITE_CONTEXT *newWriteContext(char *outputDirectory, char *filingId)
 {
   WRITE_CONTEXT *context = (WRITE_CONTEXT *)malloc(sizeof(WRITE_CONTEXT));
@@ -118,13 +130,17 @@ int getFile(WRITE_CONTEXT *context, char *filename, const char *extension)
   // Ensure the directory exists (will silently fail if it does)
   mkdir_p(fullpath);
 
-  // Add filename to path
+  // Add the normalized filename to path
   strcat(fullpath, "/");
-  strcat(fullpath, filename);
+  char *normalizedFilename = malloc(strlen(filename + 1));
+  strcpy(normalizedFilename, filename);
+  normalize_filename(normalizedFilename);
+  strcat(fullpath, normalizedFilename);
   strcat(fullpath, extension);
 
   context->files[context->nfiles] = fopen(fullpath, "w");
-  // Free the derived full path to the file
+  // Free the derived file paths
+  free(normalizedFilename);
   free(fullpath);
   context->lastname = context->filenames[context->nfiles];
   context->lastfile = context->files[context->nfiles];


### PR DESCRIPTION
@chriszs discovered a segfault on old form types where the form type has a slash in it, e.g. "SC/10" and "SC1/9" (from filing ID 34411, for reference). This fix adopts a convention he used in his Node parser wherein filenames are normalized to convert slashes in form types to dashes.