### PR TITLE
fix: add last column support due to off by 1 error

### DIFF
--- a/src/csv_test.c
+++ b/src/csv_test.c
@@ -85,9 +85,25 @@ static char *testCsvReading()
   mu_assert("error, position != 9", parseContext.position == 9);
   mu_assert("num quotes != 0", fieldInfo.num_quotes == 0);
   mu_assert("num commas != 0", fieldInfo.num_commas == 0);
-  free(resultString);
+
+  // Reads last field when advancing
+  setString(csv, "a,b,c\nd,e,f\n");
+  initParseContextWithLine(&parseContext, &fieldInfo, csv);
+  readCsvField(&parseContext);
+  advanceField(&parseContext);
+  readCsvField(&parseContext);
+  advanceField(&parseContext);
+  readCsvField(&parseContext);
+  resultString = realloc(resultString, parseContext.end - parseContext.start + 1);
+  strncpy(resultString, parseContext.line->str + parseContext.start, parseContext.end - parseContext.start);
+  resultString[parseContext.end - parseContext.start] = 0;
+  mu_assert("field should be \"c\" without quotes", strcmp(resultString, "c") == 0);
+  mu_assert("error, position != 5", parseContext.position == 5);
+  mu_assert("num quotes != 0", fieldInfo.num_quotes == 0);
+  mu_assert("num commas != 0", fieldInfo.num_commas == 0);
 
   freeString(csv);
+  free(resultString);
   return 0;
 }
 

--- a/src/fec.c
+++ b/src/fec.c
@@ -174,8 +174,8 @@ void lookupMappings(FEC_CONTEXT *ctx, PARSE_CONTEXT *parseContext, int formStart
         }
 
         // Add null terminator
-        ctx->types[headerFields.columnIndex] = 0;
-        ctx->numFields = headerFields.columnIndex;
+        ctx->types[headerFields.columnIndex + 1] = 0;
+        ctx->numFields = headerFields.columnIndex + 1;
 
         // Free up unnecessary line memory
         freeString(headersCsv);
@@ -489,9 +489,19 @@ int parseLine(FEC_CONTEXT *ctx, char *filename)
         else
         {
           // Unknown type
-          fprintf(stderr, "Unknown type %c\n", type);
+          fprintf(stderr, "Unknown type (%c) in %s\n", type, ctx->formType);
           exit(1);
         }
+      }
+      else
+      {
+        // We shouldn't ever exceed the row length
+        char *columnContents = malloc(parseContext.end - parseContext.start + 1);
+        strncpy(columnContents, ctx->persistentMemory->line->str + parseContext.start, parseContext.end - parseContext.start);
+        columnContents[parseContext.end - parseContext.start] = 0;
+        fprintf(stderr, "Unexpected column in %s (%d): %s\n", ctx->formType, parseContext.columnIndex, columnContents);
+        free(columnContents);
+        exit(1);
       }
     }
 


### PR DESCRIPTION
Another bug identified by @chriszs — the last column isn't read in FEC files due to an off-by-one error. This pretty simple PR fixes that error and adds a bit more logging and a test case (which isn't actually what the issue was but good to have regardless).