### PR TITLE
fix: memory buffer overflow issue due to incorrect arithmetic

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -64,7 +64,7 @@ int readLine(BUFFER *buffer, STRING *string, void *data)
     char c = eof ? '\0' : buffer->buffer[buffer->bufferPos];
     buffer->bufferPos++;
     // Set the string
-    while (n > string->n + 2)
+    while (n > string->n - 2)
     {
       // Ensure the string is large enough
       growString(string);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -64,7 +64,7 @@ int readLine(BUFFER *buffer, STRING *string, void *data)
     char c = eof ? '\0' : buffer->buffer[buffer->bufferPos];
     buffer->bufferPos++;
     // Set the string
-    while (n > string->n - 2)
+    while (n + 2 > string->n)
     {
       // Ensure the string is large enough
       growString(string);

--- a/src/buffer_test.c
+++ b/src/buffer_test.c
@@ -155,7 +155,7 @@ static char *testStringExpansion()
   // Read lines
   mu_assert("Expected line length 8", readLine(buffer, s, NULL) == 8);
   mu_assert("Expected line \"The cat\n\"", strcmp(s->str, "The cat\n") == 0);
-  mu_assert("Expected n 8", s->n == 8);
+  mu_assert("Expected n 16", s->n == 16);
 
   mu_assert("Expected line length 8", readLine(buffer, s, NULL) == 8);
   mu_assert("Expected line \"and the\n\"", strcmp(s->str, "and the\n") == 0);


### PR DESCRIPTION
The logic I was using to detect if I should grow string buffers in memory used the wrong sign 🤦 