### PR TITLE
Update apt-get before installing libcurl to fix GitHub Actions failure

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -18,7 +18,9 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::latest
         shell: bash
-      - run: sudo apt install -y libcurl4-openssl-dev
+      - run: |
+          sudo apt-get update
+          sudo apt install -y libcurl4-openssl-dev
       - run: zig build
       - run: zip -j fastfec-linux-x86_64-latest.zip zig-out/bin/fastfec
       - run: mv zig-out/lib/libfastfec.so libfastfec-linux-x86_64-latest.so

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -18,7 +18,9 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::latest
         shell: bash
-      - run: sudo apt install -y libcurl4-openssl-dev
+      - run: |
+          sudo apt-get update
+          sudo apt install -y libcurl4-openssl-dev
       - run: zig build
       - run: zip -j fastfec-linux-x86_64-latest.zip zig-out/bin/fastfec
       - run: mv zig-out/lib/libfastfec.so libfastfec-linux-x86_64-latest.so

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -19,7 +19,9 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
         shell: bash
-      - run: sudo apt install -y libcurl4-openssl-dev
+      - run: |
+          sudo apt-get update
+          sudo apt install -y libcurl4-openssl-dev
       - run: zig build
       - run: zip -j fastfec-linux-x86_64-${{ steps.get_version.outputs.VERSION }}.zip zig-out/bin/fastfec
       - run: mv zig-out/lib/libfastfec.so libfastfec-linux-x86_64-${{ steps.get_version.outputs.VERSION }}.so

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           version: 0.9.0-dev.1675+3d528161c
       - name: Install system dependencies
-        run: sudo apt install -y libcurl4-openssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt install -y libcurl4-openssl-dev
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ brew install pkg-config curl
 #### Ubuntu
 
 ```sh
+sudo apt-get update
 sudo apt install -y libcurl4-openssl-dev
 ```
 


### PR DESCRIPTION
## Description

`libcurl4-openssl-dev` was [failing to install in GitHub Actions](https://github.com/washingtonpost/FastFEC/runs/6496220668?check_suite_focus=true) with the following error:

```
Run sudo apt install -y libcurl4-openssl-dev

[...snip...]

Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.10
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.10_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

 According to [this thread](https://github.com/actions/virtual-environments/issues/5470) and the [docs](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners), the solution may be to run `apt-get update` first. That's what this PR does.

## Test Steps

File PR, wait for build to work. Update: It does!
