### PR TITLE
Move zig to 0.8.1

### DIFF
--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -36,13 +36,16 @@ jobs:
             libfastfec-linux-aarch64-latest.so
             libfastfec-latest.wasm
   build-macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-10.15, macos-11, macos-12]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest


### PR DESCRIPTION
## Description

Encountered the following error when setting up zig in the test GitHub Action:

<img width="822" alt="Screen Shot 2022-06-01 at 12 02 27 PM" src="https://user-images.githubusercontent.com/1103467/171449051-5137f76d-e83d-4e44-a455-411934e33d86.png">

On examining the relevant action, the obvious network requests were to [get a list of zig versions](https://ziglang.org/download/index.json) and presumably to request one. The list of zig versions didn't return the 403 forbidden error, so that probably isn't it. But I didn't see the version of zig we were using (`0.9.0-dev.1675+3d528161c`) in there, so I suspected that was no longer available and possibly causing the error. I pinned the zig setup to 0.9.0 (update: 0.9.1) instead and that seemed to clear the error.

## Test Steps

Push to branch, wait for Action, Action succeeds.
