### PR TITLE
Move zig to 0.9.1

### DIFF
--- a/.github/workflows/beta-python-wheels.yml
+++ b/.github/workflows/beta-python-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Zig
-        run: python -m pip install ziglang==0.9.0 wheel==0.37.1
+        run: python -m pip install ziglang==0.9.1 wheel==0.37.1
 
       - name: Build wheels
         run: python python/make_wheels.py

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -71,7 +71,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -71,7 +71,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/pr-python-wheels.yml
+++ b/.github/workflows/pr-python-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Zig
-        run: python -m pip install ziglang==0.9.0 wheel==0.37.1
+        run: python -m pip install ziglang==0.9.1 wheel==0.37.1
 
       - name: Build wheels
         run: python python/make_wheels.py

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -69,7 +69,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest
@@ -69,7 +69,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::latest

--- a/.github/workflows/stable-python-wheels.yml
+++ b/.github/workflows/stable-python-wheels.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install Zig
-        run: python -m pip install ziglang==0.9.0 wheel==0.37.1
+        run: python -m pip install ziglang==0.9.1 wheel==0.37.1
 
       - name: Build wheels
         run: python python/make_wheels.py

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -74,7 +74,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -74,7 +74,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.9.1
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0-dev.1675+3d528161c
+          version: 0.9.0
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The short form of flags can be combined, e.g. `-is` would include filing IDs and
 
 ### Build system
 
-[Zig](https://ziglang.org/) is used to build and compile the project. Download and install the latest version of Zig (>=0.9.0) by following the instructions on the website (you can verify it's working by typing `zig` in the terminal and seeing help commands).
+[Zig](https://ziglang.org/) is used to build and compile the project. Download and install the latest version of Zig (>=0.9.1) by following the instructions on the website (you can verify it's working by typing `zig` in the terminal and seeing help commands).
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The short form of flags can be combined, e.g. `-is` would include filing IDs and
 
 ### Build system
 
-[Zig](https://ziglang.org/) is used to build and compile the project. Download and install the latest version of Zig (>=9.0.0) by following the instructions on the website (you can verify it's working by typing `zig` in the terminal and seeing help commands).
+[Zig](https://ziglang.org/) is used to build and compile the project. Download and install the latest version of Zig (>=0.9.0) by following the instructions on the website (you can verify it's working by typing `zig` in the terminal and seeing help commands).
 
 ### Dependencies
 

--- a/python/make_wheels.py
+++ b/python/make_wheels.py
@@ -126,7 +126,7 @@ for target_platform, zig_target, wheel_platform in matrix:
     # First clear the target directory of any stray files
     if os.path.exists(LIBRARY_DIR):
         shutil.rmtree(LIBRARY_DIR)
-    # Compile! Requires ziglang==0.9.0 to be installed
+    # Compile! Requires ziglang==0.9.1 to be installed
     subprocess.call(
         [sys.executable, "-m", "ziglang", "build", "-Dlib-only=true", f"-Dtarget={zig_target}", *sys.argv[1:]],
         cwd=PARENT_DIR,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,5 +2,5 @@
 requires = [
     "setuptools",
     "wheel",
-    "ziglang==0.9.0"
+    "ziglang==0.9.1"
 ]

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -7,5 +7,5 @@ pytest-xdist
 pytest-mock
 black
 isort
-ziglang==0.9.0
+ziglang==0.9.1
 -e .


### PR DESCRIPTION
## Description

Encountered the following error when setting up zig in the test GitHub Action:

<img width="822" alt="Screen Shot 2022-06-01 at 12 02 27 PM" src="https://user-images.githubusercontent.com/1103467/171449051-5137f76d-e83d-4e44-a455-411934e33d86.png">

On examining the relevant action, the obvious network requests were to [get a list of zig versions](https://ziglang.org/download/index.json) and presumably to request one. The list of zig versions didn't return the 403 forbidden error, so that probably isn't it. But I didn't see the version of zig we were using (`0.9.0-dev.1675+3d528161c`) in there, so I suspected that was no longer available and possibly causing the error. I pinned the zig setup to 0.9.1 instead and that seemed to clear the error.

## Test Steps

Push to branch, wait for Action, Action succeeds.
