### PR TITLE
build.zig: enable headerpad_max_install_names on MacOs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -12,6 +12,11 @@ pub fn linkPcre(vendored_pcre: bool, libExe: *std.build.LibExeObjStep) void {
             libExe.linkSystemLibrary("libpcre");
         }
     }
+    if (libExe.target.isDarwin()) {
+      // useful for package maintainers
+      // see https://github.com/ziglang/zig/issues/13388
+      libExe.headerpad_max_install_names = true;
+    }
 }
 
 pub fn build(b: *std.build.Builder) !void {
@@ -45,6 +50,11 @@ pub fn build(b: *std.build.Builder) !void {
         // Library build step
         const fastfec_lib = b.addSharedLibrary("fastfec", null, .unversioned);
         fastfec_lib.setTarget(target);
+        if (fastfec_lib.target.isDarwin()) {
+          // useful for package maintainers
+          // see https://github.com/ziglang/zig/issues/13388
+          fastfec_lib.headerpad_max_install_names = true;
+        }
         fastfec_lib.setBuildMode(mode);
         fastfec_lib.install();
         fastfec_lib.linkLibC();


### PR DESCRIPTION
Fixes error during packing on MacOS with Homebrew: Error: Failed changing dylib ID of /usr/local/Cellar/fastfec/0.1.9/lib/libfastfec.dylib
  from @rpath/libfastfec.dylib
    to /usr/local/opt/fastfec/lib/libfastfec.dylib
Error: Failed to fix install linkage

See https://github.com/ziglang/zig/issues/13388, where this is inspired from

## Description

Information about what you changed for this PR

## Link to Jira Ticket

## Test Steps

## After Screenshot(s)

## Before Screenshot(s)
