### PR TITLE
Set `headerpad_max_install_names` in `build.zig`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,6 +29,10 @@ pub fn build(b: *std.build.Builder) !void {
         const fastfec_cli = b.addExecutable("fastfec", null);
         fastfec_cli.setTarget(target);
         fastfec_cli.setBuildMode(mode);
+        if (fastfec_cli.target.isDarwin()) {
+            // useful for package maintainers
+            fastfec_cli.headerpad_max_install_names = true;
+        }
         fastfec_cli.install();
 
         fastfec_cli.linkLibC();
@@ -46,6 +50,10 @@ pub fn build(b: *std.build.Builder) !void {
         const fastfec_lib = b.addSharedLibrary("fastfec", null, .unversioned);
         fastfec_lib.setTarget(target);
         fastfec_lib.setBuildMode(mode);
+        if (fastfec_lib.target.isDarwin()) {
+            // useful for package maintainers
+            fastfec_lib.headerpad_max_install_names = true;
+        }
         fastfec_lib.install();
         fastfec_lib.linkLibC();
         fastfec_lib.addCSourceFiles(&libSources, &buildOptions);


### PR DESCRIPTION
## Description

Information about what you changed for this PR

This is needed in order to create a binary distribution of FastFEC. The built binary has references to library dependencies on the build machine that need to be rewritten to be suitable for the machine it will be installed in. This rewriting will fail without setting `headerpad_max_install_names`.

Zig also has this code in their [`build.zig`](https://github.com/ziglang/zig/blob/436e99d13ba188412b8a431b69cc9ff29c6bec4a/build.zig#L551-L554)

## Link to Jira Ticket

N/A

## Test Steps

Test `brew install --build-from-source fastfec` with and without this patch.

## After Screenshot(s)

```
❯ brew install -sv fastfec
==> Fetching fastfec
==> Downloading https://github.com/washingtonpost/FastFEC/archive/refs/tags/0.1.9.tar.gz
Already downloaded: /Users/chisquared/Library/Caches/Homebrew/downloads/4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz
==> Verifying checksum for '4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz'
/usr/bin/env tar --extract --no-same-owner --file /Users/chisquared/Library/Caches/Homebrew/downloads/4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz --directory /private/tmp/d20230222-54151-5k5k1o
/usr/bin/env cp -pR /private/tmp/d20230222-54151-5k5k1o/FastFEC-0.1.9/. /private/tmp/fastfec-20230222-54151-br2wyv/FastFEC-0.1.9
chmod -Rf +w /private/tmp/d20230222-54151-5k5k1o
==> Patching
==> zig build -Dvendored-pcre=false
==> Cleaning
==> Finishing up
ln -s ../Cellar/fastfec/0.1.9/bin/fastfec fastfec
ln -s ../Cellar/fastfec/0.1.9/lib/libfastfec.dylib libfastfec.dylib
==> Summary
🍺  /usr/local/Cellar/fastfec/0.1.9: 6 files, 1.4MB, built in 16 seconds
==> Running `brew cleanup fastfec`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

## Before Screenshot(s)

```
❯ brew install -sv fastfec
==> Fetching fastfec
==> Downloading https://github.com/washingtonpost/FastFEC/archive/refs/tags/0.1.9.tar.gz
Already downloaded: /Users/chisquared/Library/Caches/Homebrew/downloads/4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz
==> Verifying checksum for '4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz'
/usr/bin/env tar --extract --no-same-owner --file /Users/chisquared/Library/Caches/Homebrew/downloads/4db09ffd013a2ceea438e95f5c3a02b238bf18354f205650fe9e91e78dc02e12--FastFEC-0.1.9.tar.gz --directory /private/tmp/d20230222-53573-1ws025a
/usr/bin/env cp -pR /private/tmp/d20230222-53573-1ws025a/FastFEC-0.1.9/. /private/tmp/fastfec-20230222-53573-19oo5g1/FastFEC-0.1.9
chmod -Rf +w /private/tmp/d20230222-53573-1ws025a
==> zig build -Dvendored-pcre=false
==> Cleaning
==> Finishing up
ln -s ../Cellar/fastfec/0.1.9/bin/fastfec fastfec
ln -s ../Cellar/fastfec/0.1.9/lib/libfastfec.dylib libfastfec.dylib
Error: Failed changing dylib ID of /usr/local/Cellar/fastfec/0.1.9/lib/libfastfec.dylib
  from @rpath/libfastfec.dylib
    to /usr/local/opt/fastfec/lib/libfastfec.dylib
Error: Failed to fix install linkage
The formula built, but you may encounter issues using it or linking other
formulae against it.
```